### PR TITLE
Guard __del__ against incomplete objects

### DIFF
--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -65,7 +65,7 @@ class _LaminaPanelSurface(object):
     def __del__(self):
         """Call glDeleteTextures when deconstruction the object."""
 
-        if self._txtr is not None:
+        if getattr(self, '_txtr', None) is not None:
             try:
                 ogl.glDeleteTextures([self._txtr])
             except:


### PR DESCRIPTION
The `_txtr` attribute may not exist if an exception occurred during
`__init__`, but `__del__` gets called regardless. Checking for the attribute's
existence prevents an AttributeError warning during shutdown.